### PR TITLE
feat: フロント/ログイン画面作成と新規登録画面の作成とページ遷移

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ http://localhost:6006/
 
 <img width="1433" alt="スクリーンショット 2025-07-09 0 39 41" src="https://github.com/user-attachments/assets/1665de5d-c9d4-47b9-a169-c5cb3316df0b" />
 
+## バックエンド
+- サーバー起動
+```
+npm run start:dev
+```
+
+### Docker
+- ***ビルド***
+```
+cd frontend
+docker compose build
+```
+
+- ***docker起動***
+```
+cd frontend
+docker compose up -d
+```
+
+- ***docker停止***
+```
+docker compose down
+```
 
 ## スマホアプリ
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.0.1",
@@ -2517,6 +2518,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
@@ -4949,6 +4958,42 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5301,6 +5346,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.1",
@@ -27,6 +28,8 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitest/browser": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "biome": "^0.3.3",
     "eslint": "^9.9.0",
@@ -34,15 +37,13 @@
     "eslint-plugin-react-refresh": "^0.4.9",
     "eslint-plugin-storybook": "^9.0.16",
     "globals": "^15.9.0",
+    "playwright": "^1.53.2",
     "postcss": "^8.5.6",
     "storybook": "^9.0.16",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^3.2.4",
-    "@vitest/browser": "^3.2.4",
-    "playwright": "^1.53.2",
-    "@vitest/coverage-v8": "^3.2.4"
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { WelcomePage } from './pages/Home/WelcomePage'
+import { RouterProvider } from 'react-router-dom'
+import WelcomePage  from './pages/Home/WelcomePage'
+import { router } from './router'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <WelcomePage/>
+    <RouterProvider router={router}/>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/Home/WelcomePage.tsx
+++ b/frontend/src/pages/Home/WelcomePage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { FaLaptopCode } from 'react-icons/fa';
 
 export const WelcomePage = () => {
@@ -13,7 +14,9 @@ export const WelcomePage = () => {
                         <ul className="flex gap-10 text-white font-bold p-5 text-lg">
                             <li className="hover:text-yellow-400">利用説明</li>
                             <li className="hover:text-yellow-400">新規ユーザー登録</li>
-                            <li className="hover:text-yellow-400">ログイン</li>
+                            <li className="hover:text-yellow-400">
+                                <Link to='/login'>ログイン</Link>
+                            </li>
                         </ul>
                     </nav>
                 </div>

--- a/frontend/src/pages/Home/WelcomePage.tsx
+++ b/frontend/src/pages/Home/WelcomePage.tsx
@@ -13,7 +13,9 @@ export const WelcomePage = () => {
                     <nav>
                         <ul className="flex gap-10 text-white font-bold p-5 text-lg">
                             <li className="hover:text-yellow-400">利用説明</li>
-                            <li className="hover:text-yellow-400">新規ユーザー登録</li>
+                            <li className="hover:text-yellow-400">
+                                <Link to='/register'>新規ユーザー登録</Link>
+                            </li>
                             <li className="hover:text-yellow-400">
                                 <Link to='/login'>ログイン</Link>
                             </li>

--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -29,8 +29,8 @@ export const LoginPage = () => {
                     <button className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 mrounded-full shadow hover:bg-emerald-500 transition">
                         ログイン
                     </button>
-                    <p className="mt-3 text-center  *:text-2xl underline hover:text-cyan-800">
-                        <Link to = '/'>新規登録はこちら</Link>
+                    <p className="mt-3 text-center text-xl underline hover:text-cyan-800">
+                        <Link to ='/register'>新規登録はこちら</Link>
                     </p>
                 </form>
             </div>

--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom';
+import { FaLaptopCode } from 'react-icons/fa';
+
+export const LoginPage = () => {
+    return (
+        <div className="flex items-center justify-center max-h-screen bg-white p-10">
+            <div className="bg-gradient-to-r from-cyan-400 to-cyan-500 p-10 rounded-lg shadow-lg w-full max-w-md text-center">
+                <h1 className="text-2xl flex items-center justify-center mb-5">
+                    <FaLaptopCode /> テックブログ共有アプリ
+                </h1>
+                <h2 className="text-xl font-bold mb-6">ログイン</h2>
+                <form className="flex flex-col gap-6 text-left">
+                    <div>
+                        <p className="font-bold mb-3">メールアドレス</p>
+                        <input
+                            type="email"
+                            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-800"
+                            placeholder="メールアドレス*"
+                        />
+                    </div>
+                    <div>
+                        <p className="font-bold mb-3">パスワード</p>
+                        <input
+                            type="password"
+                            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-800"
+                            placeholder="********"
+                        />
+                    </div>
+                    <button className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 mrounded-full shadow hover:bg-emerald-500 transition">
+                        ログイン
+                    </button>
+                    <p className="mt-3 text-center  *:text-2xl underline hover:text-cyan-800">
+                        <Link to = '/'>新規登録はこちら</Link>
+                    </p>
+                </form>
+            </div>
+        </div>
+
+    )
+}

--- a/frontend/src/pages/Register/RegisterPage.tsx
+++ b/frontend/src/pages/Register/RegisterPage.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import { FaLaptopCode } from 'react-icons/fa';
+
+export const RegisterPage = () => {
+    return (
+        <div className="flex items-center justify-center max-h-screen bg-white p-10">
+            <div className="bg-gradient-to-r from-cyan-400 to-cyan-500 p-10 rounded-lg shadow-lg w-full max-w-md text-center">
+                <h1 className="text-2xl flex items-center justify-center mb-5">
+                    <FaLaptopCode /> テックブログ共有アプリ
+                </h1>
+                <h2 className="text-xl font-bold mb-6">新規登録する</h2>
+                <form className="flex flex-col gap-6 text-left">
+                    <div>
+                        <p className="font-bold mb-3">名前</p>
+                        <input
+                            type="email"
+                            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-800"
+                            placeholder="名前を入力してください*"
+                        />
+                    </div>
+                    <div>
+                        <p className="font-bold mb-3">メールアドレス</p>
+                        <input
+                            type="email"
+                            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-800"
+                            placeholder="メールアドレスを入力してください"
+                        />
+                    </div>
+                    <div>
+                        <p className="font-bold mb-3">パスワード</p>
+                        <input
+                            type="password"
+                            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-800"
+                            placeholder="8文字以上の半角英数字"
+                        />
+                    </div>
+                    <button className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 mrounded-full shadow hover:bg-emerald-500 transition">
+                        ログイン
+                    </button>
+                    <p className="mt-3 text-center text-xl underline hover:text-cyan-800">
+                        <Link to = '/login'>ログインはこちら</Link>
+                    </p>
+                </form>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,8 +1,10 @@
 import { createBrowserRouter } from 'react-router-dom'; 
 import { WelcomePage } from './pages/Home/WelcomePage';
 import { LoginPage } from './pages/Login/LoginPage'; 
+import { RegisterPage } from './pages/Register/RegisterPage';
 
 export const router = createBrowserRouter([
     {path:'/',element: <WelcomePage/>},
-    {path:'/login',element: <LoginPage/>}
+    {path:'/login',element: <LoginPage/>},
+    {path:'/register',element: <RegisterPage/>}
 ])

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,8 @@
+import { createBrowserRouter } from 'react-router-dom'; 
+import { WelcomePage } from './pages/Home/WelcomePage';
+import { LoginPage } from './pages/Login/LoginPage'; 
+
+export const router = createBrowserRouter([
+    {path:'/',element: <WelcomePage/>},
+    {path:'/login',element: <LoginPage/>}
+])

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1232,6 +1232,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+
 core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz"
@@ -2670,7 +2675,7 @@ react-docgen@^8.0.0:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", react-dom@^18.3.1:
+"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", react-dom@^18.3.1, react-dom@>=18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -2688,7 +2693,22 @@ react-is@^17.0.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react@*, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", react@^18.3.1, react@>=16:
+react-router-dom@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz"
+  integrity sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==
+  dependencies:
+    react-router "7.6.3"
+
+react-router@7.6.3:
+  version "7.6.3"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz"
+  integrity sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==
+  dependencies:
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+
+react@*, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", react@^18.3.1, react@>=16, react@>=18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -2885,6 +2905,11 @@ semver@^7.5.3, semver@^7.6.0, semver@^7.6.2:
   version "7.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/Article-Share-App/issues/21#issue-3213176050
### WelcomePage
WelcomePageのヘッターからログイン画面、新規登録画面に遷移

### 新規登録画面

<img width="1439" height="779" alt="スクリーンショット 2025-07-12 0 37 50" src="https://github.com/user-attachments/assets/e1b3abb9-009a-4f02-ae5f-ed9d22b5ef24" />

### ログイン画面
<img width="1434" height="767" alt="スクリーンショット 2025-07-12 0 38 19" src="https://github.com/user-attachments/assets/6fb67f81-8b20-4e6d-bec5-57e27bed4dec" />
