### PR TITLE
feat: shared/atomsディレクトリを作って共通のボタンを作成(ログインと新規登録)

### DIFF
--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { FaLaptopCode } from 'react-icons/fa';
+import { AuthButton } from '../../shared/atoms/auth/AuthButton';
 
 export const LoginPage = () => {
     return (
@@ -26,9 +27,9 @@ export const LoginPage = () => {
                             placeholder="********"
                         />
                     </div>
-                    <button className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 mrounded-full shadow hover:bg-emerald-500 transition">
+                    <AuthButton>
                         ログイン
-                    </button>
+                    </AuthButton>
                     <p className="mt-3 text-center text-xl underline hover:text-cyan-800">
                         <Link to ='/register'>新規登録はこちら</Link>
                     </p>

--- a/frontend/src/pages/Register/RegisterPage.tsx
+++ b/frontend/src/pages/Register/RegisterPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { FaLaptopCode } from 'react-icons/fa';
+import { AuthButton } from '../../shared/atoms/auth/AuthButton';
 
 export const RegisterPage = () => {
     return (
@@ -8,7 +9,7 @@ export const RegisterPage = () => {
                 <h1 className="text-2xl flex items-center justify-center mb-5">
                     <FaLaptopCode /> テックブログ共有アプリ
                 </h1>
-                <h2 className="text-xl font-bold mb-6">新規登録する</h2>
+                <h2 className="text-xl font-bold mb-6">新規登録</h2>
                 <form className="flex flex-col gap-6 text-left">
                     <div>
                         <p className="font-bold mb-3">名前</p>
@@ -34,9 +35,9 @@ export const RegisterPage = () => {
                             placeholder="8文字以上の半角英数字"
                         />
                     </div>
-                    <button className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 mrounded-full shadow hover:bg-emerald-500 transition">
-                        ログイン
-                    </button>
+                    <AuthButton>
+                        登録する
+                    </AuthButton>
                     <p className="mt-3 text-center text-xl underline hover:text-cyan-800">
                         <Link to = '/login'>ログインはこちら</Link>
                     </p>

--- a/frontend/src/shared/atoms/auth/AuthButton.tsx
+++ b/frontend/src/shared/atoms/auth/AuthButton.tsx
@@ -1,0 +1,11 @@
+type PropsType = {
+    children:ReactNode;
+}
+
+export const AuthButton = ({children}: PropsType) => {
+    return (
+        <button className="w-full bg-emerald-600 hover:shadow-lg text-white rounded-lg font-bold py-3 mt-5 mrounded-full shadow hover:bg-emerald-500 transition">
+            {children}
+        </button>
+    )
+}


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/Article-Share-App/issues/10#issue-3209662535

<img width="1434" height="748" alt="スクリーンショット 2025-07-12 4 14 51" src="https://github.com/user-attachments/assets/923d88a1-9c64-4cf1-9479-2938f9389347" />

<img width="1437" height="761" alt="スクリーンショット 2025-07-12 4 15 05" src="https://github.com/user-attachments/assets/be485043-94c0-4162-ad1a-e89617222778" />
