### PR TITLE
feat: 記認証ボタン(ログインと新規登録ボタンをカタログ化)

### DIFF
--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,11 +1,12 @@
 import type { Preview } from '@storybook/react-vite'
+import '../src/index.css'; 
 
 const preview: Preview = {
   parameters: {
     controls: {
       matchers: {
-       color: /(background|color)$/i,
-       date: /Date$/i,
+        color: /(background|color)$/i,
+        date: /Date$/i,
       },
     },
   },

--- a/frontend/src/stories/AuthButton.stories.tsx
+++ b/frontend/src/stories/AuthButton.stories.tsx
@@ -1,0 +1,22 @@
+import { AuthButton } from '../shared/components/atoms/auth/AuthButton';
+
+const meta: Meta<typeof AuthButton> = {
+  title: 'Atoms/AuthButton',
+  component: AuthButton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AuthButton>;
+
+export const Login: Story = {
+  args: {
+    children: 'ログイン',
+  },
+};
+
+export const Register: Story = {
+  args: {
+    children: '新規登録',
+  },
+};


### PR DESCRIPTION
<img width="1439" height="756" alt="スクリーンショット 2025-07-14 21 41 36" src="https://github.com/user-attachments/assets/e492e34d-fe48-4550-b4b4-83a40a8fa46d" />

<img width="1432" height="749" alt="スクリーンショット 2025-07-14 21 42 02" src="https://github.com/user-attachments/assets/2a8ff388-f9e7-4a8c-84c0-235765c98a1a" />

<img width="1436" height="727" alt="スクリーンショット 2025-07-14 21 42 13" src="https://github.com/user-attachments/assets/4e9988ac-04c1-4bf3-aef3-bcbb4f82afdd" />
