### PR TITLE
chore: バックエンド(main.tsにフロントエンド、スマホアプリからAPIが叩けるように設定)

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,11 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // CORS を許可（React、React NativeからAPI叩けるように）
+  app.enableCors({
+    origin: '*', // もしくは ['http://localhost:3000'] など
+  });
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/Article-Share-App/issues/65#issue-3236079411

- enableCors は REST でも GraphQL でも同じ

- origin: '*' で全許可できるが、本番では限定推奨。

- app.listen() でポートを開ければOK。