### PR TITLE
chore: ESLintのアラートを自動で修正してくれるように設定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    }
+}


### PR DESCRIPTION
- 保存時に ESLint が提案する自動修正を 常に実行する
```.vscode/settings.json
{
    "editor.codeActionsOnSave": {
        "source.fixAll.eslint": "explicit"
    }
}
```
存時に 明示的に「ESLint で修正する」と指定した場合だけ 実行される
（"explicit" は VSCode 1.75 以降で導入されたオプションです）